### PR TITLE
Add stream to site after object creation

### DIFF
--- a/src/stores/EditStore.js
+++ b/src/stores/EditStore.js
@@ -68,6 +68,9 @@ class EditStore {
       config
     });
 
+    yield this.CreateSiteLinks({objectId});
+    yield this.AddStreamToSite({objectId});
+
     try {
       yield this.client.SetPermission({
         objectId,
@@ -252,7 +255,8 @@ class EditStore {
         libraryId: dataStore.siteLibraryId,
         objectId: dataStore.siteId,
         writeToken,
-        commitMessage: "Add live stream"
+        commitMessage: "Add live stream",
+        awaitCommitConfirmation: true
       });
     } catch(error) {
       console.error("Failed to replace meta", error);

--- a/src/stores/EditStore.js
+++ b/src/stores/EditStore.js
@@ -264,37 +264,41 @@ class EditStore {
   });
 
   UpdateStreamLink = flow(function * ({objectId, slug}) {
-    const originalLink = yield this.client.ContentObjectMetadata({
-      libraryId: dataStore.siteLibraryId,
-      objectId: dataStore.siteId,
-      metadataSubtree: `public/asset_metadata/live_streams/${slug}`,
-    });
+    try {
+      const originalLink = yield this.client.ContentObjectMetadata({
+        libraryId: dataStore.siteLibraryId,
+        objectId: dataStore.siteId,
+        metadataSubtree: `public/asset_metadata/live_streams/${slug}`,
+      });
 
-    const link = this.CreateLink({
-      targetHash: yield this.client.LatestVersionHash({objectId}),
-      options: originalLink
-    });
+      const link = this.CreateLink({
+        targetHash: yield this.client.LatestVersionHash({objectId}),
+        options: originalLink
+      });
 
-    const {writeToken} = yield this.client.EditContentObject({
-      libraryId: dataStore.siteLibraryId,
-      objectId: dataStore.siteId
-    });
+      const {writeToken} = yield this.client.EditContentObject({
+        libraryId: dataStore.siteLibraryId,
+        objectId: dataStore.siteId
+      });
 
-    yield this.client.ReplaceMetadata({
-      libraryId: dataStore.siteLibraryId,
-      objectId: dataStore.siteId,
-      writeToken,
-      metadataSubtree: `public/asset_metadata/live_streams/${slug}`,
-      metadata: link
-    });
+      yield this.client.ReplaceMetadata({
+        libraryId: dataStore.siteLibraryId,
+        objectId: dataStore.siteId,
+        writeToken,
+        metadataSubtree: `public/asset_metadata/live_streams/${slug}`,
+        metadata: link
+      });
 
-    yield this.client.FinalizeContentObject({
-      libraryId: dataStore.siteLibraryId,
-      objectId: dataStore.siteId,
-      writeToken,
-      commitMessage: "Update stream link",
-      awaitCommitConfirmation: true
-    });
+      yield this.client.FinalizeContentObject({
+        libraryId: dataStore.siteLibraryId,
+        objectId: dataStore.siteId,
+        writeToken,
+        commitMessage: "Update stream link",
+        awaitCommitConfirmation: true
+      });
+    } catch(error) {
+      console.error("Unable to update stream link", error);
+    }
   });
 
   DeleteStream = flow(function * ({objectId}) {

--- a/src/stores/StreamStore.js
+++ b/src/stores/StreamStore.js
@@ -1,6 +1,6 @@
 // Force strict mode so mutations are only allowed within actions.
 import {configure, flow, makeAutoObservable, runInAction} from "mobx";
-import {dataStore} from "./index";
+import {editStore} from "./index";
 import UrlJoin from "url-join";
 
 configure({
@@ -66,11 +66,8 @@ class StreamStore {
 
     yield this.client.StreamConfig({name: objectId, customSettings});
 
-    // Update site links after stream configuration
-    yield this.client.UpdateContentObjectGraph({
-      libraryId: dataStore.siteLibraryId,
-      versionHash: yield this.client.LatestVersionHash({objectId: dataStore.siteId})
-    });
+    // Update stream link in site after stream configuration
+    yield editStore.UpdateStreamLink({objectId, slug});
 
     const response = yield this.CheckStatus({
       objectId

--- a/src/stores/StreamStore.js
+++ b/src/stores/StreamStore.js
@@ -1,6 +1,6 @@
 // Force strict mode so mutations are only allowed within actions.
 import {configure, flow, makeAutoObservable, runInAction} from "mobx";
-import {editStore} from "./index";
+import {dataStore} from "./index";
 import UrlJoin from "url-join";
 
 configure({
@@ -65,8 +65,12 @@ class StreamStore {
     }
 
     yield this.client.StreamConfig({name: objectId, customSettings});
-    yield editStore.CreateSiteLinks({objectId});
-    yield editStore.AddStreamToSite({objectId});
+
+    // Update site links after stream configuration
+    yield this.client.UpdateContentObjectGraph({
+      libraryId: dataStore.siteLibraryId,
+      versionHash: yield this.client.LatestVersionHash({objectId: dataStore.siteId})
+    });
 
     const response = yield this.CheckStatus({
       objectId


### PR DESCRIPTION
Currently, a stream is added to the site object after configuring. This change adds the stream after object creation and updates the site links after configuring.