### PR TITLE
Remove re-configure after updating stream meta

### DIFF
--- a/src/components/Inputs.jsx
+++ b/src/components/Inputs.jsx
@@ -97,7 +97,6 @@ export const TextInput = ({
         type="text"
         name={formName}
         required={required}
-        defaultValue=""
         value={value ? value : ""}
         onChange={onChange ? onChange : undefined}
         placeholder={placeholder}

--- a/src/pages/create/AudioTracksTable.jsx
+++ b/src/pages/create/AudioTracksTable.jsx
@@ -25,7 +25,7 @@ const AudioTracksTable = observer(({
     <DataTable
       idAccessor="stream_index"
       noRecordsText="No audio tracks found"
-      minHeight={records.length > 0 ? 350 : 200}
+      minHeight={records.length > 0 ? 150 : 200}
       fetching={!disabled && !audioFormData}
       records={records}
       withColumnBorders

--- a/src/stores/StreamStore.js
+++ b/src/stores/StreamStore.js
@@ -1,6 +1,6 @@
 // Force strict mode so mutations are only allowed within actions.
 import {configure, flow, makeAutoObservable} from "mobx";
-import {editStore, streamStore} from "./index";
+import {editStore} from "./index";
 import UrlJoin from "url-join";
 import {dataStore} from "./index";
 import {FileInfo} from "@/utils/helpers";
@@ -739,7 +739,7 @@ class StreamStore {
         endTime
       });
     } catch(error) {
-       
+
       console.error("Unable to copy to VoD.", error);
       throw error(error);
     }
@@ -790,7 +790,7 @@ class StreamStore {
     }
   });
 
-  UpdateStreamAudioSettings = flow(function * ({objectId, slug, audioData}) {
+  UpdateStreamAudioSettings = flow(function * ({objectId, audioData}) {
     const libraryId = yield this.client.ContentObjectLibraryId({objectId});
     const {writeToken} = yield this.client.EditContentObject({
       libraryId,
@@ -811,18 +811,6 @@ class StreamStore {
       writeToken,
       commitMessage: "Update metadata",
       awaitCommitConfirmation: true
-    });
-
-    const probeMetadata = yield this.client.ContentObjectMetadata({
-      libraryId,
-      objectId,
-      metadataSubtree: "live_recording_config/probe_info"
-    });
-
-    yield streamStore.ConfigureStream({
-      objectId,
-      slug,
-      probeMetadata
     });
   });
 }


### PR DESCRIPTION
- Minimize audio tracks table height (currently too much empty space)
- Do not re-configure stream after updating audio stream metadata