### PR TITLE
Add dash options to encryption options text

### DIFF
--- a/src/pages/stream-details/playout/PlayoutPanel.jsx
+++ b/src/pages/stream-details/playout/PlayoutPanel.jsx
@@ -165,7 +165,7 @@ const PlayoutPanel = observer(({
         />
       </Box>
 
-      <Box data-disabled={status !== STATUS_MAP.STOPPED} mb={24} maw="50%" className={classes.box}>
+      <Box data-disabled={![STATUS_MAP.INACTIVE, STATUS_MAP.STOPPED].includes(status)} mb={24} maw="50%" className={classes.box}>
         <div className="form__section-header">DVR</div>
 
         <Box mb={24}>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -42,12 +42,12 @@ export const DRM_MAP = {
 };
 
 export const ENCRYPTION_OPTIONS = [
-  {value: "drm-public", label: "DRM - Public Access", title: "Playout Formats - HLS Sample AES, HLS AES-128", format: DRM_MAP.PUBLIC, id: "drm-public"},
-  {value: "drm-all", label: "DRM - All Formats", title: "Playout Formats - HLS Sample AES, HLS AES-128, HLS Fairplay", format: DRM_MAP.ALL, id: "drm-all"},
+  {value: "drm-public", label: "DRM - Public Access", title: "Playout Formats - HLS Sample AES, HLS AES-128, Dash Widevine, Dash PlayReady", format: DRM_MAP.PUBLIC, id: "drm-public"},
+  {value: "drm-all", label: "DRM - All Formats", title: "Playout Formats - HLS Sample AES, HLS AES-128, HLS Fairplay, Dash Widevine, Dash PlayReady", format: DRM_MAP.ALL, id: "drm-all"},
   {value: "drm-fairplay", label: "DRM - Fairplay", title: "Playout Formats - HLS Fairplay", format: DRM_MAP.FAIRPLAY, id: "drm-fairplay"},
   {value: "drm-widevine", label: "DRM - HLS Widevine", title: "Playout Formats - HLS Widevine", format: DRM_MAP.HLS_WIDEVINE, id: "drm-widevine"},
   {value: "drm-playready", label: "DRM - HLS PlayReady", title: "Playout Formats - HLS PlayReady", format: DRM_MAP.PLAYREADY, id: "drm-playready"},
-  {value: "clear", label: "Clear", title: "Playout Formats - HLS Clear", format: DRM_MAP.CLEAR, id: "clear"}
+  {value: "clear", label: "Clear", title: "Playout Formats - HLS Clear, Dash Clear", format: DRM_MAP.CLEAR, id: "clear"}
 ];
 
 export const QUALITY_MAP = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -33,10 +33,10 @@ export const DEFAULT_WATERMARK_TEXT = {
 };
 
 export const DRM_MAP = {
-  ALL: ["hls-sample-aes", "hls-aes128", "hls-fairplay", "hls-widevine-cenc", "hls-playready-cenc"],
-  PUBLIC: ["hls-sample-aes", "hls-aes128"],
+  ALL: ["hls-sample-aes", "hls-aes128", "hls-fairplay", "hls-widevine-cenc", "hls-playready-cenc", "dash-widevine", "dash-playready-cenc"],
+  PUBLIC: ["hls-sample-aes", "hls-aes128", "dash-widevine", "dash-playready-cenc"],
   FAIRPLAY: ["hls-fairplay"],
-  CLEAR: ["hls-clear"],
+  CLEAR: ["hls-clear", "dash-clear"],
   HLS_WIDEVINE: ["hls-widevine-cenc"],
   PLAYREADY: ["hls-playready-cenc"]
 };


### PR DESCRIPTION
- Add dash-widevine and dash-playready-cenc to the list of "strict DRM" (and "all DRM")
- Add dash-clear when we don't use DRM (in addition to hls-clear)




