### PR TITLE
Change dash-playready-cenc to hls-playready-cenc

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -55,7 +55,7 @@ export const DEFAULT_WATERMARK_IMAGE = {
 
 export const DRM_MAP = {
   ALL: ["hls-sample-aes", "hls-aes128", "hls-fairplay", "hls-widevine-cenc", "hls-playready-cenc", "dash-widevine", "dash-playready-cenc"],
-  PUBLIC: ["hls-sample-aes", "hls-aes128", "dash-widevine", "dash-playready-cenc"],
+  PUBLIC: ["hls-sample-aes", "hls-aes128", "dash-widevine", "hls-playready-cenc"],
   FAIRPLAY: ["hls-fairplay"],
   CLEAR: ["hls-clear", "dash-clear"],
   HLS_WIDEVINE: ["hls-widevine-cenc"],


### PR DESCRIPTION
## PR Summary: Purpose & Testing

Change dash-playready-cenc to hls-playready-cenc.

### Purpose
When DRM public is selected, the wrong playready cenc format is passed. It should be hls, not dash.

### Key Changes
*What files or functions changed?*
* `src/utils/constants.js`: [Updated `dash-playready-cenc` to `hls-playready-cenc`.]

### How to Test
*The three quickest steps for validation.*
1. Create a live stream with "all" selected for DRM type.
2. Verify the stream has hls-playready-cenc, not dash-playready-cenc

---

## Related Issues / Tickets

No ticket

---

## Breaking Changes / Risks

*Check the applicable box and explain any potential risk.*

-   [x] **No** breaking changes or high-risk areas.
-   [ ] **Yes**, this PR includes breaking changes (Explain the impact and migration path below).
-   [ ] **Potential Risk:** [Explain any risk, e.g., This refactoring touches an area with complex legacy logic.]

---

## Screenshots / Visuals

N/A
